### PR TITLE
Plugin Modifications

### DIFF
--- a/WEB_ROOT/admin/district/incident_title_codeset_pref.html
+++ b/WEB_ROOT/admin/district/incident_title_codeset_pref.html
@@ -1,6 +1,7 @@
 <script>
-  ;(function ($) {
+  ;(function ($, tps_custom) {
     $(function () {
+      if (!tps_custom) return;
       var $tr = $('form table tbody tr td:contains("~[text:psx.html.admin_district.misc-district.enable_incident_management_in_teacher_portal]")').closest('tr');
 
       var $pref_input = $('#incident-title-dropdown-pref tbody').children(':first');
@@ -19,13 +20,11 @@
         return errors;
       }
 
-      if (!validator) {
-        console.log(errors);
-      } else {
+      if (tps_custom.load(validator, "Adding enhanced teacher referral")) {
         $pref_input.insertAfter($tr).removeClass();
       }
     });
-  })(jQuery);
+  })(jQuery, window.tps_custom);
 </script>
 
 <style>

--- a/WEB_ROOT/admin/district/incident_title_codeset_pref.html
+++ b/WEB_ROOT/admin/district/incident_title_codeset_pref.html
@@ -1,0 +1,44 @@
+<script>
+  ;(function ($) {
+    $(function () {
+      var $tr = $('form table tbody tr td:contains("~[text:psx.html.admin_district.misc-district.enable_incident_management_in_teacher_portal]")').closest('tr');
+
+      var $pref_input = $('#incident-title-dropdown-pref tbody').children(':first');
+
+      function validator() {
+        var errors = [];
+
+        if ($tr.length !== 1) {
+          errors.push('should be exactly one $tr');
+        }
+
+        if ($pref_input.length !== 1) {
+          errors.push('should be exactly one $pref_input');
+        }
+
+        return errors;
+      }
+
+      if (!validator) {
+        console.log(errors);
+      } else {
+        $pref_input.insertAfter($tr).removeClass();
+      }
+    });
+  })(jQuery);
+</script>
+
+<style>
+  .tps_custom--hidden {
+    display: none;
+  }
+</style>
+
+<table id="incident-title-dropdown-pref">
+  <tbody>
+    <tr class="tps_custom--hidden">
+      <td class="bold">Enable Title Codeset Dropdown for PowerTeacher Referral Plugin</td>
+      <td><input type="checkbox" name="[pref]use_incident_title_dropdown" value="1" /></td>
+    </tr>
+  </tbody>
+</table>

--- a/WEB_ROOT/admin/district/misc-district.incident_title_codeset_pref.content.footer.txt
+++ b/WEB_ROOT/admin/district/misc-district.incident_title_codeset_pref.content.footer.txt
@@ -1,0 +1,1 @@
+~[x:insertfile;incident_title_codeset_pref.html]

--- a/WEB_ROOT/teachers/referralNew.html
+++ b/WEB_ROOT/teachers/referralNew.html
@@ -15,18 +15,25 @@
             // This query pulls only students rostered to the teacher
             // In my testing teachers can only submit referrals for students rostered to them
             ~[tlist_sql;
-                    SELECT DISTINCT
-            s.dcid,
-                s.first_name || ' ' || s.last_name || ' (ID ' || s.student_number || ', Grade ' || s.grade_level || ')' AS studentdata
-            FROM 
-                        sectionteacher st,
-                cc cc,
-                    students s
-                    WHERE st.teacherid = ~[x: userid]
-                        AND st.sectionid = cc.sectionid
-                        AND cc.studentid = s.id
-                        AND cc.schoolid = ~(curschoolid)
-                        AND s.enroll_status = 0
+                with sl as (select distinct st.sectionid, s.dcid
+                , s.first_name || ' ' || s.last_name || ' (ID ' || s.student_number || ', Grade ' || s.grade_level || ')' AS studentdata
+                    , s.lastfirst
+                    , ROW_NUMBER() OVER(PARTITION BY s.dcid order by s.dcid) r 
+                from sectionteacher st
+                left join cc on st.sectionid = cc.sectionid
+                inner join sections se on cc.sectionid = se.id
+                left join courses c on cc.course_number = c.course_number
+                inner join terms t on cc.termid = t.id
+                join students s on cc.studentid = s.id
+                where st.teacherid = 141150
+                and cc.schoolid = 730
+                and cc.termid >= 100 * (substr(extract(year from add_months(sysdate, -6)), -2) + 10)
+                
+                order by s.lastfirst)
+                
+                SELECT sl.dcid, sl.studentdata
+                    FROM(SELECT * FROM sl
+                WHERE sl.r = 1) sl
                 ]
 
             myStudents.push({

--- a/WEB_ROOT/teachers/referralNew.html
+++ b/WEB_ROOT/teachers/referralNew.html
@@ -217,13 +217,35 @@
                                 <input type="text" id="incidentLocation" name="incidentLocation" value="" size="60">
                             </td>
                         </tr>
+                        <!-- ~[if.pref.use_incident_title_dropdown=1] -->
                         <tr>
                             <td>~[text]psx.html.teachers_studentpages.incidentManagement.incident_Title[/text]</td>
                             <td>
-                                <input type="text" id="incidentTitle" class="required unvalidated tagged"
-                                    name="incidentTitle" size="60" value=""><em>*</em>
+                                <select id="incidentTitle" class="required unvalidated tagged" name="incidentTitle" value="">
+                                    <option value="" disabled selected></option>
+                                    <!-- 
+                                                              ~[tlist_sql;
+                                                                SELECT CodeSet.DisplayValue value, CodeSet.DisplayValue label
+                                                                FROM CodeSet
+                                                                WHERE CodeSet.CodeType = 'Incident Mgmt Title'
+                                                              ] 
+                                                          -->
+                                    <option value="~(value)">~(label)</option>
+                                    <!--
+                                                            [/tlist_sql]
+                                                          -->
+                                </select>
                             </td>
                         </tr>
+                        <!-- [else] -->
+                        <tr>
+                            <td>~[text]psx.html.teachers_studentpages.incidentManagement.incident_Title[/text]</td>
+                            <td>
+                                <input type="text" id="incidentTitle" class="required unvalidated tagged" name="incidentTitle" size="60"
+                                    value=""><em>*</em>
+                            </td>
+                        </tr>
+                        <!-- [/if] -->
                         </tr>
                         <tr>
                             <td valign="top">

--- a/WEB_ROOT/teachers/referralNew.html
+++ b/WEB_ROOT/teachers/referralNew.html
@@ -25,8 +25,8 @@
                 left join courses c on cc.course_number = c.course_number
                 inner join terms t on cc.termid = t.id
                 join students s on cc.studentid = s.id
-                where st.teacherid = 141150
-                and cc.schoolid = 730
+                where st.teacherid = ~(curtchrid)
+                and cc.schoolid = ~(curschoolid)
                 and cc.termid >= 100 * (substr(extract(year from add_months(sysdate, -6)), -2) + 10)
                 
                 order by s.lastfirst)


### PR DESCRIPTION
Modified the PowerTeacher Enhanced Referrals plugin to use an incident title dropdown instead of an input field based on a preference setting.

-- Added a preference to the Additional System Preferences page: Enable Title Codeset Dropdown for PowerTeacher Referral Plugin
-- Added a section of code inside of a PSHTML if statement in the new referral file.
-- Replaced the Participant Selection dropdown sql query to improve list accuracy.

## TEST
-- Check the Enable Title Codeset Dropdown for PowerTeacher Referral Plugin
-- Log into the teacher portal using an active teacher account.
-- Create a new referral.
-- Check the referral review page to confirm the referral was submitted.
-- Click the referral date to check the detail slide out.
-- Check the referral review page and detail slide out using the student pages dropdown for the selected student.
-- Change the Enable Title Codeset Dropdown for PowerTeacher Referral Plugin setting.
-- Repeat the above process.

![new_teach_ref](https://github.com/tulsaschoolsdata/powerteacher_enhanced_referral_plugin/assets/12748021/99ab1ce8-368f-4bb2-a6fe-89a3425ed08e)

![referral_review](https://github.com/tulsaschoolsdata/powerteacher_enhanced_referral_plugin/assets/12748021/f638155c-1eb1-43dc-b77e-d5921d0a7f76)

![referral_review_individual](https://github.com/tulsaschoolsdata/powerteacher_enhanced_referral_plugin/assets/12748021/b92a67c4-15ac-40cb-856a-9a57a052ad7e)

